### PR TITLE
27 prevent duplicate main script and force main script to end of file

### DIFF
--- a/src/ManiaTemplates/Components/MtComponentScript.cs
+++ b/src/ManiaTemplates/Components/MtComponentScript.cs
@@ -19,7 +19,7 @@ public class MtComponentScript
     public static MtComponentScript FromNode(ManiaTemplateEngine engine, XmlNode node)
     {
         string? content = null;
-        bool main = false, once = false;
+        var once = false;
 
         if (node.InnerXml.Length > 0)
         {
@@ -49,15 +49,10 @@ public class MtComponentScript
                 "Script tags need to either specify a body or resource-attribute.");
         }
 
-        if (DetectMainMethodRegex.IsMatch(content))
-        {
-            main = true;
-        }
-
         return new MtComponentScript
         {
             Content = content,
-            HasMainMethod = main,
+            HasMainMethod = DetectMainMethodRegex.IsMatch(content),
             Once = once
         };
     }

--- a/src/ManiaTemplates/Components/MtComponentScript.cs
+++ b/src/ManiaTemplates/Components/MtComponentScript.cs
@@ -17,9 +17,9 @@ public class MtComponentScript
         string? content = null;
         bool main = false, once = false;
 
-        if (node.InnerText.Length > 0)
+        if (node.InnerXml.Length > 0)
         {
-            content = node.InnerText;
+            content = node.InnerXml;
         }
 
         if (node.Attributes != null)

--- a/src/ManiaTemplates/Components/MtComponentScript.cs
+++ b/src/ManiaTemplates/Components/MtComponentScript.cs
@@ -9,6 +9,7 @@ public class MtComponentScript
     public required string Content { get; init; }
     public required bool HasMainMethod { get; init; }
     public required bool Once { get; init; }
+    public int Depth { get; set; }
 
     private static readonly Regex DetectMainMethodRegex = new(@"(?s)main\(\).*\{.*\}");
     
@@ -41,7 +42,7 @@ public class MtComponentScript
                 }
             }
         }
-
+        
         if (content == null)
         {
             throw new ManiaScriptSourceMissingException(

--- a/src/ManiaTemplates/Components/MtComponentScript.cs
+++ b/src/ManiaTemplates/Components/MtComponentScript.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Text.RegularExpressions;
+using System.Xml;
 using ManiaTemplates.Exceptions;
 
 namespace ManiaTemplates.Components;
@@ -6,9 +7,11 @@ namespace ManiaTemplates.Components;
 public class MtComponentScript
 {
     public required string Content { get; init; }
-    public required bool Main { get; init; }
+    public required bool HasMainMethod { get; init; }
     public required bool Once { get; init; }
 
+    private static readonly Regex DetectMainMethodRegex = new(@"(?s)main\(\).*\{.*\}");
+    
     /// <summary>
     /// Creates a MtComponentScript instance from a components script-node.
     /// </summary>
@@ -32,10 +35,6 @@ public class MtComponentScript
                         content = engine.GetManiaScript(attribute.Value);
                         break;
 
-                    case "main":
-                        main = true;
-                        break;
-
                     case "once":
                         once = true;
                         break;
@@ -49,10 +48,15 @@ public class MtComponentScript
                 "Script tags need to either specify a body or resource-attribute.");
         }
 
+        if (DetectMainMethodRegex.IsMatch(content))
+        {
+            main = true;
+        }
+
         return new MtComponentScript
         {
             Content = content,
-            Main = main,
+            HasMainMethod = main,
             Once = once
         };
     }

--- a/src/ManiaTemplates/Exceptions/DuplicateMainManiaScriptException.cs
+++ b/src/ManiaTemplates/Exceptions/DuplicateMainManiaScriptException.cs
@@ -1,0 +1,18 @@
+﻿namespace ManiaTemplates.Exceptions;
+
+public class DuplicateMainManiaScriptException : Exception
+{
+    public DuplicateMainManiaScriptException()
+    {
+    }
+
+    public DuplicateMainManiaScriptException(string message)
+        : base(message)
+    {
+    }
+
+    public DuplicateMainManiaScriptException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/ManiaTemplates/Lib/MtTransformer.cs
+++ b/src/ManiaTemplates/Lib/MtTransformer.cs
@@ -588,7 +588,7 @@ public class MtTransformer
             maniaScripts[key] = value;
         }
 
-        var mainSet = false;
+        var mainMethodSet = false;
         var scripts = new StringBuilder();
         var scriptMethod = new Snippet
         {
@@ -597,15 +597,15 @@ public class MtTransformer
 
         foreach (var script in maniaScripts.Values) //TODO: sort by depth
         {
-            if (script.Main)
+            if (script.HasMainMethod)
             {
-                if (mainSet)
+                if (mainMethodSet)
                 {
                     throw new DuplicateMainManiaScriptException(
-                        "You may only include one script with main-attribute. Offending script: " + script.Content);
+                        "You may only include one main-method per ManiaLink. Offending script:\n" + script.Content);
                 }
 
-                mainSet = true;
+                mainMethodSet = true;
             }
 
             scripts.AppendLine(script.Content);

--- a/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
+++ b/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
@@ -29,7 +29,7 @@ public class MtComponentScriptTest
 
         var res = MtComponentScript.FromNode(_templateEngine, document.DocumentElement!);
         Assert.Equal("text", res.Content);
-        Assert.Equal(expectedMain, res.Main);
+        Assert.Equal(expectedMain, res.HasMainMethod);
         Assert.Equal(expectedOnce, res.Once);
     }
 

--- a/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
+++ b/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
@@ -15,13 +15,9 @@ public class MtComponentScriptTest
 
     [Theory]
     [InlineData("<script>text</script>", false, false)]
-    [InlineData("<script main=''>text</script>", true, false)]
     [InlineData("<script once=''>text</script>", false, true)]
-    [InlineData("<script main='' once=''>text</script>", true, true)]
     [InlineData("<script resource='res'/>", false, false)]
-    [InlineData("<script resource='res' main=''/>", true, false)]
     [InlineData("<script resource='res' once=''/>", false, true)]
-    [InlineData("<script resource='res' main='' once=''/>", true, true)]
     public void Should_Load_ManiaScript(string input, bool expectedMain, bool expectedOnce)
     {
         var document = new XmlDocument();
@@ -35,7 +31,7 @@ public class MtComponentScriptTest
 
     [Theory]
     [InlineData("<script/>")]
-    [InlineData("<script main='false' once='true' />")]
+    [InlineData("<script once='true' />")]
     public void Should_Fail_To_Load_Empty_ManiaScript(string input)
     {
         var document = new XmlDocument();

--- a/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
+++ b/tests/ManiaTemplates.Tests/Components/MtComponentScriptTest.cs
@@ -30,6 +30,20 @@ public class MtComponentScriptTest
     }
 
     [Theory]
+    [InlineData("<script>main(){ //dummy comment }</script>", true, false)]
+    [InlineData("<script once=''>main(){ //dummy comment }</script>", true, true)]
+    public void Should_Load_ManiaScriptMainMethod(string input, bool expectedMain, bool expectedOnce)
+    {
+        var document = new XmlDocument();
+        document.LoadXml(input);
+
+        var res = MtComponentScript.FromNode(_templateEngine, document.DocumentElement!);
+        Assert.Equal("main(){ //dummy comment }", res.Content);
+        Assert.Equal(expectedMain, res.HasMainMethod);
+        Assert.Equal(expectedOnce, res.Once);
+    }
+
+    [Theory]
     [InlineData("<script/>")]
     [InlineData("<script once='true' />")]
     public void Should_Fail_To_Load_Empty_ManiaScript(string input)

--- a/tests/ManiaTemplates.Tests/Components/MtComponentTest.cs
+++ b/tests/ManiaTemplates.Tests/Components/MtComponentTest.cs
@@ -47,7 +47,7 @@ public class MtComponentTest
                     <slot/>
                 </template>
                 
-                <script resource="res" main="notUsed">scriptText1</script>
+                <script resource="res"><!--main(){}--></script>
                 <script once="notUsed">scriptText1</script>
                 <script once="notUsed">scriptText2</script>
                 <script>scriptText3</script>
@@ -55,7 +55,7 @@ public class MtComponentTest
         """;
         
         _engine.GetType().GetField("_maniaScripts", BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(_engine,
-            new Dictionary<string, string> { { "res", "resourceScript" } });
+            new Dictionary<string, string> { { "res", "<!--main(){}-->" } });
         
         var expected = new MtComponent
         {
@@ -68,7 +68,7 @@ public class MtComponentTest
                 },
             Scripts = new()
             {
-                new() { Content = "resourceScript", HasMainMethod = true, Once = false },
+                new() { Content = "<!--main(){}-->", HasMainMethod = true, Once = false },
                 new() { Content = "scriptText1", HasMainMethod = false, Once = true },
                 new() { Content = "scriptText2", HasMainMethod = false, Once = true },
                 new() { Content = "scriptText3", HasMainMethod = false, Once = false }

--- a/tests/ManiaTemplates.Tests/Components/MtComponentTest.cs
+++ b/tests/ManiaTemplates.Tests/Components/MtComponentTest.cs
@@ -68,10 +68,10 @@ public class MtComponentTest
                 },
             Scripts = new()
             {
-                new() { Content = "resourceScript", Main = true, Once = false },
-                new() { Content = "scriptText1", Main = false, Once = true },
-                new() { Content = "scriptText2", Main = false, Once = true },
-                new() { Content = "scriptText3", Main = false, Once = false }
+                new() { Content = "resourceScript", HasMainMethod = true, Once = false },
+                new() { Content = "scriptText1", HasMainMethod = false, Once = true },
+                new() { Content = "scriptText2", HasMainMethod = false, Once = true },
+                new() { Content = "scriptText3", HasMainMethod = false, Once = false }
             },
             HasSlot = true,
             ImportedComponents = new()

--- a/tests/ManiaTemplates.Tests/IntegrationTests/expected/nested-controls.xml
+++ b/tests/ManiaTemplates.Tests/IntegrationTests/expected/nested-controls.xml
@@ -6,6 +6,6 @@
 </test>
 </frame>
 </frame>
-<script><!--
---></script>
+<script>
+</script>
 </manialink>

--- a/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
+++ b/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
@@ -72,7 +72,7 @@ public class MtTransformerTest
                     Scripts = new List<MtComponentScript>()
                     {
                         new() { Content = "GraphScript", HasMainMethod = false, Once = false },
-                        new() { Content = "GraphScript", HasMainMethod = false, Once = true }
+                        new() { Content = "GraphScript", HasMainMethod = false, Once = true },
                     },
                     HasSlot = false,
                     ImportedComponents = new MtComponentMap(),
@@ -121,8 +121,8 @@ public class MtTransformerTest
         var output = _maniaTemplateEngine.RenderAsync("RecursionRoot", new {}, assemblies).Result;
         Assert.Equal( @$"<manialink version=""3"" id=""MtRecursionRoot"" name=""EvoSC#-MtRecursionRoot"">
 <el />
-<script><!--
---></script>
+<script>
+</script>
 </manialink>
 ", output, ignoreLineEndingDifferences: true);
     }

--- a/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
+++ b/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
@@ -22,9 +22,9 @@ public class MtTransformerTest
             },
         Scripts = new()
         {
-            new() { Content = "scriptText1", Main = true, Once = false },
-            new() { Content = "scriptText2", Main = false, Once = true },
-            new() { Content = "scriptText3", Main = false, Once = false }
+            new() { Content = "scriptText1", HasMainMethod = true, Once = false },
+            new() { Content = "scriptText2", HasMainMethod = false, Once = true },
+            new() { Content = "scriptText3", HasMainMethod = false, Once = false }
         },
         HasSlot = true,
         ImportedComponents =
@@ -71,8 +71,8 @@ public class MtTransformerTest
                         },
                     Scripts = new List<MtComponentScript>()
                     {
-                        new() { Content = "GraphScript", Main = false, Once = false },
-                        new() { Content = "GraphScript", Main = false, Once = true }
+                        new() { Content = "GraphScript", HasMainMethod = false, Once = false },
+                        new() { Content = "GraphScript", HasMainMethod = false, Once = true }
                     },
                     HasSlot = false,
                     ImportedComponents = new MtComponentMap(),

--- a/tests/ManiaTemplates.Tests/Lib/expected.tt
+++ b/tests/ManiaTemplates.Tests/Lib/expected.tt
@@ -92,12 +92,12 @@ Render_Component_MtContext2(__slotRenderer: () => Render_Slot_8(__data));
 }
 void RenderManiaScripts() {
 #>
-<script><!--
+<script>
+GraphScript
 scriptText1
 scriptText2
 scriptText3
-GraphScript
---></script>
+</script>
 <#+
 }
 #>


### PR DESCRIPTION
Changes:

- Add detect `main()` automatically
- Throw exception if two main-methods are detected
- Force script containing main-method to be inserted at bottom
- Merge maniascripts sorted by depth (descending)
- Fix load maniascripts from within script-tags