### PR TITLE
20 variables in mania scripts

### DIFF
--- a/src/ManiaTemplates/Components/MtComponentScript.cs
+++ b/src/ManiaTemplates/Components/MtComponentScript.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml;
 using ManiaTemplates.Exceptions;
 
@@ -57,8 +59,8 @@ public class MtComponentScript
         };
     }
 
-    public int ContentHash()
+    public string ContentHash()
     {
-        return Content.GetHashCode();
+        return Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(Content)));
     }
 }

--- a/src/ManiaTemplates/Languages/MtLanguageT4.cs
+++ b/src/ManiaTemplates/Languages/MtLanguageT4.cs
@@ -12,7 +12,7 @@ public class MtLanguageT4 : IManiaTemplateLanguage
 
     public string InsertResult(string content)
     {
-        return $"<#= {content} #>";
+        return $"<#= ({content}) #>";
     }
 
     public string Code(string content)

--- a/src/ManiaTemplates/Lib/MtTransformer.cs
+++ b/src/ManiaTemplates/Lib/MtTransformer.cs
@@ -358,8 +358,16 @@ public class MtTransformer
         {
             if (component.Properties.TryGetValue(attributeName, out var value))
             {
-                renderArguments.Add(
-                    $"{attributeName}: {WrapIfString(value, ReplaceCurlyBraces(attributeValue, s => IsStringType(value) ? $@"{{{s}}}" : s))}");
+                if (IsStringType(value))
+                {
+                    renderArguments.Add(
+                        $"{attributeName}: {WrapIfString(value, ReplaceCurlyBraces(attributeValue, s =>  $@"{{({s})}}"))}");
+                }
+                else
+                {
+                    renderArguments.Add(
+                        $"{attributeName}: {ReplaceCurlyBraces(attributeValue, s => $"({s})")}"); 
+                }
             }
         }
 
@@ -442,7 +450,7 @@ public class MtTransformer
         arguments.AddRange(component.Properties.Values.OrderBy(property => property.Default != null).Select(property =>
             property.Default == null
                 ? $"{property.Type} {property.Name}"
-                : $"{property.Type} {property.Name} = {WrapIfString(property, property.Default)}"));
+                : $"{property.Type} {property.Name} = {(WrapIfString(property, property.Default))}"));
 
         //close method arguments
         renderMethod.Append(string.Join(", ", arguments))

--- a/src/ManiaTemplates/ManiaTemplateEngine.cs
+++ b/src/ManiaTemplates/ManiaTemplateEngine.cs
@@ -107,9 +107,9 @@ public class ManiaTemplateEngine
     /// <summary>
     /// PreProcesses a template-key for faster rendering.
     /// </summary>
-    public void PreProcess(string key, IEnumerable<Assembly> assemblies)
+    public void PreProcess(string key, IEnumerable<Assembly> assemblies, string? writeTo = null)
     {
-        _preProcessed[key] = PreProcessComponent(GetComponent(key), ManialinkNameUtils.KeyToId(key), assemblies);
+        _preProcessed[key] = PreProcessComponent(GetComponent(key), ManialinkNameUtils.KeyToId(key), assemblies, writeTo);
     }
 
     /// <summary>

--- a/tests/ManiaTemplates.Tests/IntegrationTests/expected/nested-controls.xml
+++ b/tests/ManiaTemplates.Tests/IntegrationTests/expected/nested-controls.xml
@@ -6,6 +6,4 @@
 </test>
 </frame>
 </frame>
-<script>
-</script>
 </manialink>

--- a/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
+++ b/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
@@ -91,8 +91,6 @@ public class MtTransformerTest
         var result = _transformer.BuildManialink(_testComponent, "expected");
         var generalizedResult = TransformCodeToOrderNumber(result);
         
-        _testOutputHelper.WriteLine(generalizedResult);
-
         Assert.Equal(expected, generalizedResult, ignoreLineEndingDifferences: true);
     }
 

--- a/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
+++ b/tests/ManiaTemplates.Tests/Lib/MtTransformerTest.cs
@@ -3,11 +3,13 @@ using System.Text.RegularExpressions;
 using ManiaTemplates.Components;
 using ManiaTemplates.Languages;
 using ManiaTemplates.Lib;
+using Xunit.Abstractions;
 
 namespace ManiaTemplates.Tests.Lib;
 
 public class MtTransformerTest
 {
+    private readonly ITestOutputHelper _testOutputHelper;
     private readonly ManiaTemplateEngine _maniaTemplateEngine = new();
     private readonly Regex _hashCodePattern = new("[0-9]{6,10}");
 
@@ -47,8 +49,9 @@ public class MtTransformerTest
 
     private readonly MtTransformer _transformer;
 
-    public MtTransformerTest()
+    public MtTransformerTest(ITestOutputHelper testOutputHelper)
     {
+        _testOutputHelper = testOutputHelper;
         _transformer = new MtTransformer(_maniaTemplateEngine, new MtLanguageT4());
     }
 
@@ -87,6 +90,8 @@ public class MtTransformerTest
         var expected = File.ReadAllText("Lib/expected.tt");
         var result = _transformer.BuildManialink(_testComponent, "expected");
         var generalizedResult = TransformCodeToOrderNumber(result);
+        
+        _testOutputHelper.WriteLine(generalizedResult);
 
         Assert.Equal(expected, generalizedResult, ignoreLineEndingDifferences: true);
     }
@@ -121,8 +126,6 @@ public class MtTransformerTest
         var output = _maniaTemplateEngine.RenderAsync("RecursionRoot", new {}, assemblies).Result;
         Assert.Equal( @$"<manialink version=""3"" id=""MtRecursionRoot"" name=""EvoSC#-MtRecursionRoot"">
 <el />
-<script>
-</script>
 </manialink>
 ", output, ignoreLineEndingDifferences: true);
     }

--- a/tests/ManiaTemplates.Tests/Lib/expected.tt
+++ b/tests/ManiaTemplates.Tests/Lib/expected.tt
@@ -38,7 +38,7 @@ var __outerIndex1 = 0;
 foreach (int i in numbers) {
 var __index = __outerIndex1;
 if (enabled) {
-Render_Component_MtContext2(x: 20 * __index, __slotRenderer: () => Render_Slot_3(new CRoot_ForEachLoop1(__data){__index = __index, i = i}));
+Render_Component_MtContext2(x: (20 * __index), __slotRenderer: () => Render_Slot_3(new CRoot_ForEachLoop1(__data){__index = __index, i = i}));
 }
 __outerIndex1++;
 }
@@ -59,12 +59,12 @@ scriptText3
 }
 void Render_Component_MtContext5(double x = 0.0, double y = 0.0, double w = 0.0, double h = 0.0, string halign = $"left", string valign = $"center", double opacity = 1.0, int zIndex = 0, int events = 0, string action = $"", string url = $"", string manialink = $"", string style = $"", string textfont = $"GameFont", double textsize = 1.0, string textcolor = $"", string focusareacolor1 = $"", string focusareacolor2 = $"", string text = $"", string textprefix = $"", int bold = 0, int autonewline = 0, int maxline = 0, int translate = 0, string textid = $"", string id = $"") {
 #>
-<label pos="<#= x #> <#= y #>" size="<#= w #> <#= h #>" halign="<#= halign #>" valign="<#= valign #>" opacity="<#= opacity #>" z-index="<#= zIndex #>" ScriptEvents="<#= events #>" action="<#= action #>" url="<#= url #>" manialink="<#= manialink #>" style="<#= style #>" textfont="<#= textfont #>" textsize="<#= textsize #>" textcolor="<#= textcolor #>" focusareacolor1="<#= focusareacolor1 #>" focusareacolor2="<#= focusareacolor2 #>" text="<#= text #>" textprefix="<#= textprefix #>" textemboss="<#= bold #>" autonewline="<#= autonewline #>" maxline="<#= maxline #>" translate="<#= translate #>" textid="<#= textid #>" id="<#= id #>" />
+<label pos="<#= (x) #> <#= (y) #>" size="<#= (w) #> <#= (h) #>" halign="<#= (halign) #>" valign="<#= (valign) #>" opacity="<#= (opacity) #>" z-index="<#= (zIndex) #>" ScriptEvents="<#= (events) #>" action="<#= (action) #>" url="<#= (url) #>" manialink="<#= (manialink) #>" style="<#= (style) #>" textfont="<#= (textfont) #>" textsize="<#= (textsize) #>" textcolor="<#= (textcolor) #>" focusareacolor1="<#= (focusareacolor1) #>" focusareacolor2="<#= (focusareacolor2) #>" text="<#= (text) #>" textprefix="<#= (textprefix) #>" textemboss="<#= (bold) #>" autonewline="<#= (autonewline) #>" maxline="<#= (maxline) #>" translate="<#= (translate) #>" textid="<#= (textid) #>" id="<#= (id) #>" />
 <#+
 }
 void Render_Component_MtContext2(Action __slotRenderer, int zIndex = 0, double x = 0.0, double y = 0.0, double w = 0.0, double h = 0.0) {
 #>
-<frame pos="<#= x #> <#= y #>" size="<#= w #> <#= h #>" z-index="<#= zIndex #>">
+<frame pos="<#= (x) #> <#= (y) #>" size="<#= (w) #> <#= (h) #>" z-index="<#= (zIndex) #>">
 <#+
 __slotRenderer();
 #>
@@ -94,7 +94,7 @@ var __outerIndex7 = 0;
 foreach (int j in numbers.GetRange(0, i)) {
 var __index2 = __outerIndex7;
 if (i < numbers.Count) {
-Render_Component_MtContext5(text: $"{i}, {j} at index {__index}, {__index2}");
+Render_Component_MtContext5(text: $"{(i)}, {(j)} at index {(__index)}, {(__index2)}");
 }
 __outerIndex7++;
 }
@@ -105,7 +105,7 @@ var enabled = __data.enabled;
 #>
 <test>
 <#+
-Render_Component_MtContext6(arg3: new test());
+Render_Component_MtContext6(arg3: (new test()));
 #>
 </test>
 <#+

--- a/tests/ManiaTemplates.Tests/Lib/expected.tt
+++ b/tests/ManiaTemplates.Tests/Lib/expected.tt
@@ -5,7 +5,6 @@
 <manialink version="3" id="expected" name="EvoSC#-expected">
 <#
 RenderBody(() => DoNothing());
-RenderManiaScripts();
 #>
 </manialink>
 <#+
@@ -31,6 +30,7 @@ __index = data.__index;
 i = data.i;
 }
 }
+List<string> __insertedOneTimeManiaScripts = new List<string>();
 string DoNothing(){return "";}
 void RenderBody(Action __slotRenderer) {
 var __data = new CRoot { numbers = numbers,enabled = enabled };
@@ -43,6 +43,19 @@ Render_Component_MtContext2(x: 20 * __index, __slotRenderer: () => Render_Slot_3
 __outerIndex1++;
 }
 Render_Component_MtContext2(__slotRenderer: () => Render_Slot_4(__data));
+#>
+<script>scriptText1
+<#+
+if(!__insertedOneTimeManiaScripts.Contains("0zU/AjjFBI5iWuZPX521w2ZluB8P21bd48fEgb65Qz4=")){
+#>
+scriptText2
+<#+
+__insertedOneTimeManiaScripts.Add("0zU/AjjFBI5iWuZPX521w2ZluB8P21bd48fEgb65Qz4=");
+}
+#>
+scriptText3
+</script>
+<#+
 }
 void Render_Component_MtContext5(double x = 0.0, double y = 0.0, double w = 0.0, double h = 0.0, string halign = $"left", string valign = $"center", double opacity = 1.0, int zIndex = 0, int events = 0, string action = $"", string url = $"", string manialink = $"", string style = $"", string textfont = $"GameFont", double textsize = 1.0, string textcolor = $"", string focusareacolor1 = $"", string focusareacolor2 = $"", string text = $"", string textprefix = $"", int bold = 0, int autonewline = 0, int maxline = 0, int translate = 0, string textid = $"", string id = $"") {
 #>
@@ -59,6 +72,18 @@ __slotRenderer();
 <#+
 }
 void Render_Component_MtContext6(test arg3, string arg1 = $"", int arg2 = 0) {
+#>
+<script>GraphScript
+<#+
+if(!__insertedOneTimeManiaScripts.Contains("FWKSFxnFcgdsXVn9dn5IW3isD6T8z+2eK6liK8rPSpU=")){
+#>
+GraphScript
+<#+
+__insertedOneTimeManiaScripts.Add("FWKSFxnFcgdsXVn9dn5IW3isD6T8z+2eK6liK8rPSpU=");
+}
+#>
+</script>
+<#+
 }
 void Render_Slot_3(CRoot_ForEachLoop1 __data) {
 var numbers = __data.numbers;
@@ -89,15 +114,5 @@ void Render_Slot_4(CRoot __data) {
 var numbers = __data.numbers;
 var enabled = __data.enabled;
 Render_Component_MtContext2(__slotRenderer: () => Render_Slot_8(__data));
-}
-void RenderManiaScripts() {
-#>
-<script>
-GraphScript
-scriptText1
-scriptText2
-scriptText3
-</script>
-<#+
 }
 #>


### PR DESCRIPTION
- Allow {{ }} in ManiaScripts
- Extract directives and put them at the top of the ManiaLink
- Wrap arguments for methods and inserts in parenthesis (allows to use ternary more easily)